### PR TITLE
Add JSZone wrapper

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,9 +112,10 @@ OBJFILES =	accounts.o \
 			jsoncpp/json_reader.o \
 			jsoncpp/json_value.o \
 			jsoncpp/json_writer.o \
-			js/JSQuery.o \
-			js/JSRoom.o \
-			js/JSRow.o \
+                        js/JSQuery.o \
+                        js/JSRoom.o \
+                        js/JSZone.o \
+                        js/JSRow.o \
 			kedit.o \
 			ku/kuClient.o \
 			ku/kuDescriptor.o \

--- a/src/js/JSZone.cpp
+++ b/src/js/JSZone.cpp
@@ -1,0 +1,28 @@
+#include "../conf.h"
+
+#include "JSZone.h"
+#include "js_interpreter.h"
+
+void JSEnvironment::LoadJSZone()
+{
+    load_class<JSZone>();
+}
+
+void JSZone::echo(flusspferd::string message)
+{
+    if(real)
+        sendToZone(flusspferd::string::concat(message, "\r\n").c_str(), real->GetRnum());
+}
+
+void JSZone::reset()
+{
+    if(real)
+        real->Reset();
+}
+
+int JSZone::distanceTo(JSZone *other)
+{
+    if(real && other && other->toReal())
+        return real->Distance(other->toReal());
+    return -1;
+}

--- a/src/js/JSZone.h
+++ b/src/js/JSZone.h
@@ -1,0 +1,63 @@
+#ifndef KINSLAYER_JSZONE_H
+#define KINSLAYER_JSZONE_H
+
+#include <flusspferd.hpp>
+#include <string>
+
+#include "../zones.h"
+#include "js_utils.h"
+#include "JSRoom.h" // for sendToZone declaration
+
+using namespace flusspferd;
+using namespace std;
+
+FLUSSPFERD_CLASS_DESCRIPTION(
+    JSZone,
+    (full_name, "JSZone")
+    (constructor_name, "JSZone")
+    (methods,
+        ("echo", bind, echo)
+        ("reset", bind, reset)
+        ("distanceTo", bind, distanceTo)
+    )
+    (properties,
+        ("name", getter, getName)
+        ("vnum", getter, getVnum)
+        ("bottom", getter, getBottom)
+        ("top", getter, getTop)
+        ("lifespan", getter, getLifespan)
+        ("age", getter, getAge)
+        ("closed", getter, getClosed)
+        ("x", getter, getX)
+        ("y", getter, getY)
+    ))
+{
+public:
+    JSZone(flusspferd::object const &self, flusspferd::call_context& cc)
+        : base_type(self) {}
+    JSZone(flusspferd::object const &self, Zone *real)
+        : base_type(self) { this->real = real; }
+    ~JSZone() {}
+
+    Zone *toReal() { return real; }
+    void setReal(Zone *z) { real = z; }
+
+    flusspferd::string getName() { return real ? real->getName() : ""; }
+    int getVnum() { return real ? real->getVnum() : -1; }
+    int getBottom() { return real ? real->GetBottom() : 0; }
+    int getTop() { return real ? real->GetTop() : 0; }
+    int getLifespan() { return real ? real->GetLifespan() : 0; }
+    int getAge() { return real ? real->GetAge() : 0; }
+    bool getClosed() { return real ? real->IsClosed() : true; }
+    int getX() { return real ? real->GetX() : 0; }
+    int getY() { return real ? real->GetY() : 0; }
+
+    void echo(flusspferd::string message);
+    void reset();
+    int distanceTo(JSZone *other);
+
+private:
+    Zone *real;
+};
+
+#endif

--- a/src/js/js_functions.cpp
+++ b/src/js/js_functions.cpp
@@ -22,6 +22,7 @@
 #include "../Descriptor.h"
 #include "../CharacterUtil.h"
 #include "../rooms/Room.h"
+#include "../zones.h"
 
 
 extern const int rev_dir[];
@@ -1100,9 +1101,17 @@ void JS_mudLog( int type, int lvl, flusspferd::string str )
 }
 flusspferd::value JS_getRoomByRnum( int rnum )
 {
-	if( rnum >= 0 && rnum < World.size() )
-		return lookupValue( World[rnum] );
-	return lookupValue( 0 );
+        if( rnum >= 0 && rnum < World.size() )
+                return lookupValue( World[rnum] );
+        return lookupValue( 0 );
+}
+
+flusspferd::value JS_getZone( int vnum )
+{
+        Zone *zone = ZoneManager::GetManager().GetZoneByVnum(vnum);
+        if(!zone)
+                return flusspferd::object();
+        return lookupValue(zone);
 }
 
 void JS_fwrite( flusspferd::string fileName, flusspferd::string str )

--- a/src/js/js_functions.h
+++ b/src/js/js_functions.h
@@ -49,6 +49,7 @@ void JS_fwrite( flusspferd::string fileName, flusspferd::string str );
 flusspferd::string JS_fread( flusspferd::string fileName );
 flusspferd::value JS_getRoom( int vnum );
 flusspferd::value JS_getRoomByRnum( int rnum );
+flusspferd::value JS_getZone( int vnum );
 void JS_mudLog( int type, int lvl, flusspferd::string str );
 
 int JS_getHour();

--- a/src/js/js_interpreter.cpp
+++ b/src/js/js_interpreter.cpp
@@ -144,18 +144,20 @@ void triggerOperationalCallback(flusspferd::context context)
 JSEnvironment::JSEnvironment()
     : context_scope(context::create())
 {
-	LoadJSCharacter();
-	LoadJSRoom();
-	LoadJSObject();
-	LoadJSQuery();
+        LoadJSCharacter();
+        LoadJSRoom();
+        LoadJSZone();
+        LoadJSObject();
+        LoadJSQuery();
 	LoadJSRow();
 
 	gcCount=0;
 
 	object g = global();
     g.set_property("constants", makeConstants());
-	flusspferd::create_native_function(g, "getRoom", JS_getRoom);
-	flusspferd::create_native_function(g, "getRoomByRnum", JS_getRoomByRnum);
+        flusspferd::create_native_function(g, "getRoom", JS_getRoom);
+        flusspferd::create_native_function(g, "getRoomByRnum", JS_getRoomByRnum);
+        flusspferd::create_native_function(g, "getZone", JS_getZone);
 	flusspferd::create_native_function(g, "mudLog", JS_mudLog);
 	flusspferd::create_native_function(g, "_act", JS_act);
 	flusspferd::create_native_function(g, "fwrite", JS_fwrite);

--- a/src/js/js_interpreter.h
+++ b/src/js/js_interpreter.h
@@ -19,6 +19,7 @@
 #include "JSCharacter.h"
 #include "JSObject.h"
 #include "JSRoom.h"
+#include "JSZone.h"
 #include "js_constants.h"
 #include "js_trigger.h"
 
@@ -78,10 +79,11 @@ class JSEnvironment
         void cleanup(JSInstance*); // cleans up that instance. Its called from ~JSInstance, so it uses a raw pointer.
 
 	void LoadJSCharacter();
-	void LoadJSObject();
-	void LoadJSRoom();  
-	void LoadJSQuery();
-	void LoadJSRow();      
+        void LoadJSObject();
+        void LoadJSRoom();
+        void LoadJSZone();
+        void LoadJSQuery();
+        void LoadJSRow();
 
     private:
 		__int64 gcCount;

--- a/src/js/js_utils.cpp
+++ b/src/js/js_utils.cpp
@@ -5,6 +5,7 @@
 #include "JSObject.h"
 #include "JSQuery.h"
 #include "JSRow.h"
+#include "JSZone.h"
 
 #include "../rooms/Room.h"
 
@@ -36,10 +37,14 @@ void deleteValue( JSBindable *addr )
 		{
 			get_native<JSObject>(o).setReal( 0 );
 		}
-		else if( is_native<JSRoom>(o) )
-		{
-			get_native<JSRoom>(o).setReal( 0 );
-		}
+                else if( is_native<JSRoom>(o) )
+                {
+                        get_native<JSRoom>(o).setReal( 0 );
+                }
+                else if( is_native<JSZone>(o) )
+                {
+                        get_native<JSZone>(o).setReal( 0 );
+                }
 	}
 }
 
@@ -122,9 +127,19 @@ flusspferd::value lookupValue(JSBindable * b)
 	    return findPair<JSRoom>(r).second;
 	else if( (query = dynamic_cast<sqlJSQuery *>(b)) != 0 )
 		return findPair<JSQuery>(query).second;
-	else if( (row = dynamic_cast<sqlJSRow *>(b)) != 0 )
-	    return findPair<JSRow>(row).second;
-	return flusspferd::value();
+        else if( (row = dynamic_cast<sqlJSRow *>(b)) != 0 )
+            return findPair<JSRow>(row).second;
+        return flusspferd::value();
+}
+
+flusspferd::value lookupValue(Zone *z)
+{
+        return findPair<JSZone>(z).second;
+}
+
+std::string lookupName(Zone *z)
+{
+        return findPair<JSZone>(z).first;
 }
 
 //Created by Narg: August 2009

--- a/src/js/js_utils.h
+++ b/src/js/js_utils.h
@@ -39,6 +39,9 @@ flusspferd::value lookupValue(JSBindable * b);
 std::string lookupName(JSBindable * b);
 void deleteValue( JSBindable * addr );
 
+flusspferd::value lookupValue(Zone *z);
+std::string lookupName(Zone *z);
+
 
 /******
 


### PR DESCRIPTION
## Summary
- implement `JSZone` wrapper class for Zone
- register `JSZone` in the JS environment and make `getZone` helper
- extend utilities to handle Zone objects
- update Makefile for new source file

## Testing
- `make -C src test` *(fails: `Nothing to be done for 'test'`)*
- `make -C src -j8` *(fails: missing mysql/sqlDatabase.h)*