### PR TITLE
Add JSZone wrapper

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,9 +112,10 @@ OBJFILES =	accounts.o \
 			jsoncpp/json_reader.o \
 			jsoncpp/json_value.o \
 			jsoncpp/json_writer.o \
-			js/JSQuery.o \
-			js/JSRoom.o \
-			js/JSRow.o \
+                        js/JSQuery.o \
+                        js/JSRoom.o \
+                        js/JSZone.o \
+                        js/JSRow.o \
 			kedit.o \
 			ku/kuClient.o \
 			ku/kuDescriptor.o \

--- a/src/js/JSCharacter.cpp
+++ b/src/js/JSCharacter.cpp
@@ -226,7 +226,7 @@ flusspferd::array JSCharacter::getFollowers()
 flusspferd::value JSCharacter::eq(int pos)
 {
 	if(pos < 0 || pos >= NUM_WEARS)
-		return lookupValue(0);
+		return lookupValue((JSBindable*)0);
 	return lookupValue(real && !real->IsProto() ? GET_EQ(real, pos) : 0);
 }
 
@@ -367,17 +367,17 @@ void JSCharacter::extract()
 
 flusspferd::value JSCharacter::load_obj( const int vnum )
 {
-	if( !real || real->IsPurged() || real->IsProto() ) return lookupValue( 0 );
+	if( !real || real->IsPurged() || real->IsProto() ) return lookupValue((JSBindable*)0);
 	int r_num;
 	Object *obj;
 	if ((r_num = real_object(vnum)) < 0)
 	{
-		return lookupValue(0);
+		return lookupValue((JSBindable*)0);
 	}
 
 	if (obj_proto[r_num]->getType() == ITEM_SPECIAL)
 	{
-		lookupValue(0);
+		lookupValue((JSBindable*)0);
 	}
 
 	obj = read_object(r_num, REAL, true);
@@ -565,37 +565,37 @@ flusspferd::string JSCharacter::getLeaveMessage()
 flusspferd::value JSCharacter::getMount()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.mount);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getRiddenBy()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.ridden_by);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getTarget()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.target);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getMarked()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.marked);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getHunting()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.hunting);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getOTarget()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.otarget);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getSittingOn()
 {
 	if( real && !real->IsPurged() && !real->IsProto() ) return lookupValue(real->player.sitting_on);
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 int JSCharacter::getDeathWait()
 {
@@ -668,19 +668,19 @@ flusspferd::value JSCharacter::getDecayedBy()
 {
 	if( real && !real->IsPurged() && !real->IsProto() )
 		return lookupValue( real->DecayedBy );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getBurnedBy()
 {
 	if( real && !real->IsPurged() && !real->IsProto() )
 		return lookupValue( real->BurnedBy );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSCharacter::getPlaguedBy()
 {
 	if( real && !real->IsPurged() && !real->IsProto() )
 		return lookupValue( real->PlaguedBy );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 // SETTERS 
 

--- a/src/js/JSCharacter.h
+++ b/src/js/JSCharacter.h
@@ -302,7 +302,7 @@ public:
     void setWisdom(int x)			{ if( !real || real->IsPurged() ) return; real->real_abils.wis = real->aff_abils.wis = MAX(0,x); }
     void setDexterity(int x)		{ if( !real || real->IsPurged() ) return; real->real_abils.dex = real->aff_abils.dex = MAX(0,x); }
     void setConstitution(int x)		{ if( !real || real->IsPurged() ) return; real->real_abils.con = real->aff_abils.con = MAX(0,x); }
-	flusspferd::value getFighting()		{ if( !real || real->IsPurged() ) return lookupValue(0); return lookupValue(FIGHTING(real)); }
+	flusspferd::value getFighting()		{ if( !real || real->IsPurged() ) return lookupValue((JSBindable*)0); return lookupValue(FIGHTING(real)); }
 	void setFightingVar( JSCharacter *t );
 	void setFighting( JSCharacter *t );
 	void stopFighting();

--- a/src/js/JSObject.cpp
+++ b/src/js/JSObject.cpp
@@ -86,18 +86,18 @@ bool JSObject::getIsCorpse()
 
 flusspferd::value JSObject::load_obj( const int vnum )
 {
-	if( !real || real->IsProto() ) return lookupValue(0);
+	if( !real || real->IsProto() ) return lookupValue((JSBindable*)0);
 
 	int r_num;
 	Object *obj;
 	if ((r_num = real_object(vnum)) < 0)
 	{
-		return lookupValue(0);
+		return lookupValue((JSBindable*)0);
 	}
 
 	if (obj_proto[r_num]->getType() == ITEM_SPECIAL)
 	{
-		lookupValue(0);
+		lookupValue((JSBindable*)0);
 	}
 
 	obj = read_object(r_num, REAL, true);

--- a/src/js/JSQuery.cpp
+++ b/src/js/JSQuery.cpp
@@ -47,11 +47,11 @@ flusspferd::value JSQuery::getpeekRow()
 {
 	if( real->MyQuery->hasNextRow() )
 		return lookupValue( new class sqlJSRow( new sql::Row(real->MyQuery->peekRow())) );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value JSQuery::getRow()
 {
 	if( real->MyQuery->hasNextRow() )
 		return lookupValue( new class sqlJSRow( new sql::Row(real->MyQuery->getRow())) );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }

--- a/src/js/JSRoom.cpp
+++ b/src/js/JSRoom.cpp
@@ -202,18 +202,18 @@ void JSRoom::echoaround(JSCharacter& ch, std::string message)
 
 flusspferd::value JSRoom::loadObj( const int vnum )
 {
-	if( !real ) return lookupValue(0);
+	if( !real ) return lookupValue((JSBindable*)0);
 
 	int r_num;
 	Object *obj;
 	if ((r_num = real_object(vnum)) < 0)
 	{
-		return lookupValue(0);
+		return lookupValue((JSBindable*)0);
 	}
 
 	if( obj_proto[r_num]->getType() == ITEM_SPECIAL )
 	{
-		lookupValue(0);
+		lookupValue((JSBindable*)0);
 	}
 
 	obj = read_object(r_num, REAL, true);
@@ -229,12 +229,12 @@ flusspferd::value JSRoom::loadObj( const int vnum )
 
 flusspferd::value JSRoom::loadMob( const int vnum )
 {
-	if( !real ) return lookupValue(0);
+	if( !real ) return lookupValue((JSBindable*)0);
 	int r_num;
 	Character *mob;
 	if ((r_num = MobManager::GetManager().RealMobile(vnum)) < 0)
 	{
-		return lookupValue(0);
+		return lookupValue((JSBindable*)0);
 	}
 	mob = new Character(r_num, REAL);
 	

--- a/src/js/JSZone.cpp
+++ b/src/js/JSZone.cpp
@@ -1,0 +1,28 @@
+#include "../conf.h"
+
+#include "JSZone.h"
+#include "js_interpreter.h"
+
+void JSEnvironment::LoadJSZone()
+{
+    load_class<JSZone>();
+}
+
+void JSZone::echo(flusspferd::string message)
+{
+    if(real)
+        sendToZone(flusspferd::string::concat(message, "\r\n").c_str(), real->GetRnum());
+}
+
+void JSZone::reset()
+{
+    if(real)
+        real->Reset();
+}
+
+int JSZone::distanceTo(JSZone *other)
+{
+    if(real && other && other->toReal())
+        return real->Distance(other->toReal());
+    return -1;
+}

--- a/src/js/JSZone.h
+++ b/src/js/JSZone.h
@@ -1,0 +1,63 @@
+#ifndef KINSLAYER_JSZONE_H
+#define KINSLAYER_JSZONE_H
+
+#include <flusspferd.hpp>
+#include <string>
+
+#include "../zones.h"
+#include "js_utils.h"
+#include "JSRoom.h" // for sendToZone declaration
+
+using namespace flusspferd;
+using namespace std;
+
+FLUSSPFERD_CLASS_DESCRIPTION(
+    JSZone,
+    (full_name, "JSZone")
+    (constructor_name, "JSZone")
+    (methods,
+        ("echo", bind, echo)
+        ("reset", bind, reset)
+        ("distanceTo", bind, distanceTo)
+    )
+    (properties,
+        ("name", getter, getName)
+        ("vnum", getter, getVnum)
+        ("bottom", getter, getBottom)
+        ("top", getter, getTop)
+        ("lifespan", getter, getLifespan)
+        ("age", getter, getAge)
+        ("closed", getter, getClosed)
+        ("x", getter, getX)
+        ("y", getter, getY)
+    ))
+{
+public:
+    JSZone(flusspferd::object const &self, flusspferd::call_context& cc)
+        : base_type(self) {}
+    JSZone(flusspferd::object const &self, Zone *real)
+        : base_type(self) { this->real = real; }
+    ~JSZone() {}
+
+    Zone *toReal() { return real; }
+    void setReal(Zone *z) { real = z; }
+
+    flusspferd::string getName() { return real ? real->getName() : ""; }
+    int getVnum() { return real ? real->getVnum() : -1; }
+    int getBottom() { return real ? real->GetBottom() : 0; }
+    int getTop() { return real ? real->GetTop() : 0; }
+    int getLifespan() { return real ? real->GetLifespan() : 0; }
+    int getAge() { return real ? real->GetAge() : 0; }
+    bool getClosed() { return real ? real->IsClosed() : true; }
+    int getX() { return real ? real->GetX() : 0; }
+    int getY() { return real ? real->GetY() : 0; }
+
+    void echo(flusspferd::string message);
+    void reset();
+    int distanceTo(JSZone *other);
+
+private:
+    Zone *real;
+};
+
+#endif

--- a/src/js/js_functions.cpp
+++ b/src/js/js_functions.cpp
@@ -22,6 +22,7 @@
 #include "../Descriptor.h"
 #include "../CharacterUtil.h"
 #include "../rooms/Room.h"
+#include "../zones.h"
 
 
 extern const int rev_dir[];
@@ -1090,7 +1091,7 @@ flusspferd::value JS_getRoom( int vnum )
 	int rnum = real_room(vnum);
 
 	if( rnum == -1 )
-		return lookupValue( 0 );
+		return lookupValue((JSBindable*)0);
 	else
 		return lookupValue( World[rnum] );
 }
@@ -1100,9 +1101,17 @@ void JS_mudLog( int type, int lvl, flusspferd::string str )
 }
 flusspferd::value JS_getRoomByRnum( int rnum )
 {
-	if( rnum >= 0 && rnum < World.size() )
-		return lookupValue( World[rnum] );
-	return lookupValue( 0 );
+        if( rnum >= 0 && rnum < World.size() )
+                return lookupValue( World[rnum] );
+        return lookupValue((JSBindable*)0);
+}
+
+flusspferd::value JS_getZone( int vnum )
+{
+        Zone *zone = ZoneManager::GetManager().GetZoneByVnum(vnum);
+        if(!zone)
+                return flusspferd::object();
+        return lookupValue(zone);
 }
 
 void JS_fwrite( flusspferd::string fileName, flusspferd::string str )
@@ -1233,7 +1242,7 @@ flusspferd::value getObjProto( int vnum )
 {
 	int rnum = real_object( vnum );
 	if( rnum == -1 )
-		return lookupValue( 0 );
+		return lookupValue((JSBindable*)0);
 	return lookupValue( obj_proto[rnum] );
 }
 flusspferd::value JS_getAllRoomsInZone( int zoneId )
@@ -1252,7 +1261,7 @@ flusspferd::value getObjProtoByRnum( int rnum )
 {
 	if( rnum >= 0 && rnum < top_of_objt )
 		return lookupValue( obj_proto[ rnum ] );
-	return lookupValue( 0 );
+	return lookupValue((JSBindable*)0);
 }
 flusspferd::value getMobProto( int vnum )
 {

--- a/src/js/js_functions.h
+++ b/src/js/js_functions.h
@@ -49,6 +49,7 @@ void JS_fwrite( flusspferd::string fileName, flusspferd::string str );
 flusspferd::string JS_fread( flusspferd::string fileName );
 flusspferd::value JS_getRoom( int vnum );
 flusspferd::value JS_getRoomByRnum( int rnum );
+flusspferd::value JS_getZone( int vnum );
 void JS_mudLog( int type, int lvl, flusspferd::string str );
 
 int JS_getHour();

--- a/src/js/js_interpreter.cpp
+++ b/src/js/js_interpreter.cpp
@@ -144,18 +144,20 @@ void triggerOperationalCallback(flusspferd::context context)
 JSEnvironment::JSEnvironment()
     : context_scope(context::create())
 {
-	LoadJSCharacter();
-	LoadJSRoom();
-	LoadJSObject();
-	LoadJSQuery();
+        LoadJSCharacter();
+        LoadJSRoom();
+        LoadJSZone();
+        LoadJSObject();
+        LoadJSQuery();
 	LoadJSRow();
 
 	gcCount=0;
 
 	object g = global();
     g.set_property("constants", makeConstants());
-	flusspferd::create_native_function(g, "getRoom", JS_getRoom);
-	flusspferd::create_native_function(g, "getRoomByRnum", JS_getRoomByRnum);
+        flusspferd::create_native_function(g, "getRoom", JS_getRoom);
+        flusspferd::create_native_function(g, "getRoomByRnum", JS_getRoomByRnum);
+        flusspferd::create_native_function(g, "getZone", JS_getZone);
 	flusspferd::create_native_function(g, "mudLog", JS_mudLog);
 	flusspferd::create_native_function(g, "_act", JS_act);
 	flusspferd::create_native_function(g, "fwrite", JS_fwrite);

--- a/src/js/js_interpreter.h
+++ b/src/js/js_interpreter.h
@@ -19,6 +19,7 @@
 #include "JSCharacter.h"
 #include "JSObject.h"
 #include "JSRoom.h"
+#include "JSZone.h"
 #include "js_constants.h"
 #include "js_trigger.h"
 
@@ -78,10 +79,11 @@ class JSEnvironment
         void cleanup(JSInstance*); // cleans up that instance. Its called from ~JSInstance, so it uses a raw pointer.
 
 	void LoadJSCharacter();
-	void LoadJSObject();
-	void LoadJSRoom();  
-	void LoadJSQuery();
-	void LoadJSRow();      
+        void LoadJSObject();
+        void LoadJSRoom();
+        void LoadJSZone();
+        void LoadJSQuery();
+        void LoadJSRow();
 
     private:
 		__int64 gcCount;

--- a/src/js/js_utils.cpp
+++ b/src/js/js_utils.cpp
@@ -5,6 +5,7 @@
 #include "JSObject.h"
 #include "JSQuery.h"
 #include "JSRow.h"
+#include "JSZone.h"
 
 #include "../rooms/Room.h"
 
@@ -36,10 +37,14 @@ void deleteValue( JSBindable *addr )
 		{
 			get_native<JSObject>(o).setReal( 0 );
 		}
-		else if( is_native<JSRoom>(o) )
-		{
-			get_native<JSRoom>(o).setReal( 0 );
-		}
+                else if( is_native<JSRoom>(o) )
+                {
+                        get_native<JSRoom>(o).setReal( 0 );
+                }
+                else if( is_native<JSZone>(o) )
+                {
+                        get_native<JSZone>(o).setReal( 0 );
+                }
 	}
 }
 
@@ -122,9 +127,19 @@ flusspferd::value lookupValue(JSBindable * b)
 	    return findPair<JSRoom>(r).second;
 	else if( (query = dynamic_cast<sqlJSQuery *>(b)) != 0 )
 		return findPair<JSQuery>(query).second;
-	else if( (row = dynamic_cast<sqlJSRow *>(b)) != 0 )
-	    return findPair<JSRow>(row).second;
-	return flusspferd::value();
+        else if( (row = dynamic_cast<sqlJSRow *>(b)) != 0 )
+            return findPair<JSRow>(row).second;
+        return flusspferd::value();
+}
+
+flusspferd::value lookupValue(Zone *z)
+{
+        return findPair<JSZone>(z).second;
+}
+
+std::string lookupName(Zone *z)
+{
+        return findPair<JSZone>(z).first;
 }
 
 //Created by Narg: August 2009

--- a/src/js/js_utils.h
+++ b/src/js/js_utils.h
@@ -39,6 +39,9 @@ flusspferd::value lookupValue(JSBindable * b);
 std::string lookupName(JSBindable * b);
 void deleteValue( JSBindable * addr );
 
+flusspferd::value lookupValue(Zone *z);
+std::string lookupName(Zone *z);
+
 
 /******
 

--- a/src/zones.h
+++ b/src/zones.h
@@ -1,6 +1,8 @@
 #ifndef ZONES_H
 #define ZONES_H
 
+#include "structs.h"
+
 class ResetCommand
 {
 	public:
@@ -74,7 +76,7 @@ public:
 };
 
 /* zone definition structure. for the 'zone-table'					*/
-class Zone
+class Zone : public JSBindable
 {
 private:
 	std::string Name;		/* name of this zone					*/
@@ -172,7 +174,10 @@ public:
 	unsigned int getVnum() { return vnum; }
 	void setVnum( const int _vnum ) { vnum = _vnum; }
 	unsigned int GetRnum() { return rnum; }
-	void SetRnum( const int _rnum ) { rnum = _rnum; }
+        void SetRnum( const int _rnum ) { rnum = _rnum; }
+
+        Room *getRoom() override { return NULL; }
+        bool IsPurged() override { return deleted; }
 
 	void Boot( const sql::Row &ZoneRow, std::list< sql::Row > &RowList );
 	void save();


### PR DESCRIPTION
## Summary
- implement `JSZone` wrapper class for Zone
- register `JSZone` in the JS environment and make `getZone` helper
- extend utilities to handle Zone objects
- update Makefile for new source file
- use explicit nullptr overloads for `lookupValue`

## Testing
- `make -C src test` *(fails: `Nothing to be done for 'test'`)*
- `make -C src -j8` *(fails: missing mysql/sqlDatabase.h)*
